### PR TITLE
Tidy up get_spotify.py and build_description.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ set SPOTIFY_CLIENT_ID=xxx && set SPOTIFY_CLIENT_SECRET=xxx && set SPOTIFY_REDIRE
 To view all currently set environment variables, use the command `set`.
 
 ### Set which genres to Reject
-Create your own rejects.json file inside of the data folder. This is what the script will use to determine which genres to reject from your playlist. You can use the rejects_example as a template.
+Create your own `rejects.json` file inside of the data folder. This is what the script will use to determine which genres to reject from your playlist. You can use the rejects_example as a template.
 
 ## Running
 
-Once you have completed all the installtion steps, run New Albums script by running `py setup.py`.
+Once you have completed all the installation steps, run New Albums script by running `py setup.py`.

--- a/build_description.py
+++ b/build_description.py
@@ -1,9 +1,14 @@
-def build_description(accepted_albums):
-    description = ""
+from typing import List
+
+
+from typing import List 
+
+from classes.albumClass import albumClass
+
+def build_description(accepted_albums: List[albumClass]) -> str:
+    description = []
 
     for album in accepted_albums:
-        description += f"{album['artists'][0]['name']} "
-        description += '"'
-        description += f"{album['name']} "
-        description += '", '
-    return description
+        album_description = f'{ album["artists"][0]["name"] } " {album["name"]} "'
+        description.append(album_description)
+    return ', '.join(description)

--- a/build_description.py
+++ b/build_description.py
@@ -6,6 +6,6 @@ def build_description(accepted_albums: List[albumClass]) -> str:
     description = []
 
     for album in accepted_albums:
-        album_description = f'{ album["artists"][0]["name"] } " {album["name"]} "'
+        album_description = f'{ album["artists"][0]["name"] } "{album["name"]} "'
         description.append(album_description)
     return ', '.join(description)

--- a/build_description.py
+++ b/build_description.py
@@ -6,6 +6,6 @@ def build_description(accepted_albums: List[albumClass]) -> str:
     description = []
 
     for album in accepted_albums:
-        album_description = f'{ album["artists"][0]["name"] } "{album["name"]} "'
+        album_description = f'{ album["artists"][0]["name"] } "{album["name"]}"'
         description.append(album_description)
     return ', '.join(description)

--- a/build_description.py
+++ b/build_description.py
@@ -1,6 +1,3 @@
-from typing import List
-
-
 from typing import List 
 
 from classes.albumClass import albumClass

--- a/services/get_spotify.py
+++ b/services/get_spotify.py
@@ -1,13 +1,17 @@
 import os
+import logging
 from json.decoder import JSONDecodeError
 
 import config
 import spotipy
-import spotipy.util as util
+from spotipy import util
 
 
-def get_spotify():
-    print("get_spotify...")
+def get_spotify() -> spotipy.Spotify:
+    logging.info('get_spotify...')
+
+    token = None
+    spotify = None
 
     try:
         token = util.prompt_for_user_token(
@@ -30,5 +34,6 @@ def get_spotify():
     if token:
         spotify = spotipy.Spotify(auth=token)
     else:
-        print(config.spotify_scope_warning)
+        logging.warn(config.spotify_scope_warning)
+        raise ValueError(config.spotify_scope_warning)
     return spotify

--- a/tests/test_build_description.py
+++ b/tests/test_build_description.py
@@ -1,0 +1,29 @@
+import unittest
+
+from build_description import build_description
+
+
+class TestBuildDescription(unittest.TestCase):
+    def setUp(self) -> None:
+        self.artists = [{'name': 'Geezer'}]
+        self.accepted_albums = [{
+            'artists': self.artists,
+            'name': 'The Testing Album'
+        }, {
+            'artists': self.artists,
+            'name': 'The Second Testing Album'
+        }
+        ]
+        return super().setUp()
+
+    def tearDown(self) -> None:
+        return super().tearDown()
+
+    def testBuildSubscription(self):
+        expected = 'Geezer "The Testing Album", Geezer "The Second Testing Album"'
+        actual = build_description(self.accepted_albums)
+
+        self.assertEqual(expected, actual)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_get_spotify.py
+++ b/tests/test_get_spotify.py
@@ -1,0 +1,54 @@
+import os
+import unittest
+from unittest import mock
+
+import spotipy
+
+_MOCK_ENVVARS = {
+    'NEW_ALBUMS_PLAYLIST_ID': 'MockID',
+    'SPOTIFY_CLIENT_ID': 'MockSpotifyID',
+    'SPOTIFY_CLIENT_SECRET': 'MockSpotifySecret',
+    'SPOTIFY_REDIRECT_URI': 'MockRedirectURI',
+    'SPOTIFY_USER': 'TestMcTesterson'
+}
+
+class TestSpotify(unittest.TestCase):
+
+    def setUp(self) -> None:
+
+        mock_os = mock.patch.object(os, 'remove')
+        mock_spotipy = mock.patch.object(spotipy, 'Spotify')
+        # Mock Enviornment Variables
+        mock.patch.dict(os.environ, _MOCK_ENVVARS).start()
+        
+        self.mock_remove = mock_os.start()
+        self.mock_spotify = mock_spotipy.start()
+
+        return super().setUp()
+
+    def tearDown(self) -> None:
+        return super().tearDown()
+
+    @mock.patch.object(spotipy.util, 'prompt_for_user_token')
+    def testFailedCache(self, mock_prompt):
+        from services.get_spotify import get_spotify
+
+        mock_prompt.side_effect = [AttributeError, 'TestToken']
+        self.mock_spotify.return_value = spotipy.client.Spotify
+        ret = get_spotify()
+
+        self.assertEqual(mock_prompt.call_count, 2)
+        self.assertIsNotNone(ret)
+    
+    @mock.patch.object(spotipy.util, 'prompt_for_user_token')
+    def testRaiseValueError(self, mock_prompt):
+        from services.get_spotify import get_spotify
+        
+        mock_prompt.return_value = None
+
+        with self.assertRaises(ValueError) as ctx:
+            get_spotify()
+        self.assertEqual(mock_prompt.call_count, 1)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hi,

This change implements two minor changes, and adds some tests.

### `build_description.py`

1. Adds typing to assist with interpreters and static-analyzers the ability to determine return types.
2. Removes the appending to a string multiple times.
    * Strings are immutable and appending to a single string multiple times is computationally expensive.
    * This change implements a list of strings, which are then joined together at the end.
3. Adds a test.

### `get_spotify.py`

1. Switches from using print statements in this particular module, to logging.
2. Implements typing, as above.
3. Return a ValueError exception in cases where token is unset. This helps the caller understand that there's a missing component.

### Added `test_get_spotify.py` and `test_build_description.py`

```
python -m unittest discover
..WARNING:root:signing into spotify...
If this program or another program with the same client_id
has changed scopes, you'll need to reauthorize each time.
Make sure all programs have the same scope.
.
----------------------------------------------------------------------
Ran 3 tests in 0.008s

OK
```