### PR TITLE
Top Genres filter: add command line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The `fiat.py` file will be ignored by git.
 
 Once you have completed all the installation steps, run New Albums script by running `py setup.py`.
 
-### Filtering by country
+### Filter by country
 
 By default, the script will filter by US. To filter by a specific country, you can pass the `--country` flag followed by the country ISO code, e.g. `py setup.py --country JP`
 
@@ -47,3 +47,11 @@ By default, the script will filter by US. To filter by a specific country, you c
 - `py setup.py --country GB`: filter by GB
 - `py setup.py --country list`: list all available Spotify country codes. The script then prompts you to type an ISO code.
 - `py setup.py --country all`: include all country codes (worldwide)
+
+`-c` can also be used as an abbreviation for `--country`, e.g. `py setup.py -c all`
+
+### Filter by top genres
+
+By default, the script will not filter by top genres. To enable this filter, you can pass the `--top-genres` flag, e.g. `py setup.py --top-genres`
+
+`-g` can also be used as an abbreviation for `--top-genres`, e.g. `py setup.py -g`

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def main():
         "-g", "--top-genres", help="Allows you to filter by your top genres.", default="N", nargs="?", const="Y")
     args = parser.parse_args()
     country = args.country.upper()
-    filter_by_genre = args.top_genres.upper()
+    filter_by_genre = args.top_genres
 
     # ALL is worldwide
     if country == "ALL":

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,14 @@ parser = argparse.ArgumentParser()
 
 def main():
 
-    # Handle arguments
+    # Handle arguments (country, top genres)
     parser.add_argument("-c", "--country",
                         help="Allows you to filter by country using an ISO country code. Default is 'US'. Use 'ALL' for worldwide. Use 'LIST' to list all available countries.", default="US")
+    parser.add_argument(
+        "-g", "--top-genres", help="Allows you to filter by your top genres.", default="N", nargs="?", const="Y")
     args = parser.parse_args()
     country = args.country.upper()
+    filter_by_genre = args.top_genres.upper()
 
     # ALL is worldwide
     if country == "ALL":
@@ -37,18 +40,10 @@ def main():
         print("=============================================")
         country = input().upper()
 
-    # # Ask for filter by your user styles
-    # print("=============================================")
-    # print(" DO YOU WANT TO FILTER BY YOUR TOP GENRES. ('Y' or 'N')")
-    # print("=============================================")
-    # filter_by_genre = input()
-
     print("new_albums.setup main...")
     print("=============================================")
 
     album = albumClass(spotify)
-
-    filter_by_genre = "N"
 
     # Get albums lists
     processed_albums = album.get_new_album_ids(country, filter_by_genre)

--- a/setup.py
+++ b/setup.py
@@ -62,15 +62,14 @@ def main():
 
     # Results display screen
 
-    # if filter_by_genre.upper() == "Y":
-    #     print("=============================================")
-    #     print(" MY TOP GENRE LIST")
-    #     print("=============================================")
+    if filter_by_genre.upper() == "Y":
+        print("=============================================")
+        print(" MY TOP GENRE LIST")
+        print("=============================================")
 
-    #     user = userClass(spotify)
-    #     user.set_user_to
-    # from data import fiatp_genres()
-    #     print(f"+ {user.genres}")
+        user = userClass(spotify)
+        user.set_user_top_genres()
+        print(f"+ {user.genres}")
 
     print("=============================================")
     print(" ACCEPTED")
@@ -79,14 +78,14 @@ def main():
     for album in processed_albums.accepted:
         print(f"+ {album['name']} {album['genres']} | {album['artists'][0]['name']}")
 
-    # if filter_by_genre.upper() == "Y":
-    #     print("=============================================")
-    #     print(" REJECTED BECAUSE OF MY TOP GENRE LIST")
-    #     print("=============================================")
-    #     for album in processed_albums.rejected_by_my_top:
-    #         print(
-    #             f"+ {album['name']} {album['genres']} | {album['artists'][0]['name']}"
-    #         )
+    if filter_by_genre.upper() == "Y":
+        print("=============================================")
+        print(" REJECTED BECAUSE OF MY TOP GENRE LIST")
+        print("=============================================")
+        for album in processed_albums.rejected_by_my_top:
+            print(
+                f"+ {album['name']} {album['genres']} | {album['artists'][0]['name']}"
+            )
 
     print("=============================================")
     print(" REJECTED BY GENRE FIAT")


### PR DESCRIPTION
This follows on from https://github.com/riverscuomo/new-albums/pull/14 and adds a command line option for enabling the top genres filter.

You can now run `py setup.py --top-genres`, or `py setup.py -g`, to set `filter_by_genre` to `Y`. The default is `N` (the same as the current behaviour).

Closes https://github.com/riverscuomo/new-albums/issues/13