### PR TITLE
Feature: Support multiple countries with -c

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ poetry install
 
 ### Local development
 
-The package can be installed in develop mode to allow you to make changes locally.
+The package can be installed in developement (editable) mode to allow you to make changes locally.
 
 Traditional:
 
@@ -111,7 +111,7 @@ Traditional:
 pip install . develop`
 ```
 
-Poetry automatically installs dependencies in develop mode.
+Poetry automatically installs dependencies in development mode.
 
 ## Running
 
@@ -146,3 +146,52 @@ By default, the script will filter by US. To filter by a specific country, you c
 By default, the script will not filter by top genres. To enable this filter, you can pass the `--top-genres` flag, e.g. `py -m new_albums --top-genres`
 
 `-g` can also be used as an abbreviation for `--top-genres`, e.g. `py -m new_albums -g`
+
+### Specify an fiat file
+
+`New Albums` defaults to using `_default_fiat` as a fiat file. The option `--fiat` or `-f` for short allows using an alternative fiat file.
+
+For example, to run `New Albums` with `prog_fiat` as a fiat file:
+
+```shell
+poetry run python -m new_albums -f prog_fiat
+```
+
+Or:
+```shell
+py -m new_albums -f prog_fiat
+```
+
+### Logging granularity
+
+The `--log` or `-l` argument can be used to specify the logging level.
+
+**Valid levels:**
+
+* debug
+* info
+* warning
+* critical
+* error
+
+Usage:
+
+```shell
+poetry run python -m new_albums -l critical
+```
+
+### Limit releases
+
+Use the `--limit` or `-m` argument if you'd like to limit the amount of new releases returned. Defaults to 20 and must be > 0 or <= 50.
+
+```shell
+poetry run python -m new_albums -m 50
+```
+
+### Timeout
+
+`--timeout` or `-t` sets the amount of seconds to wait for a response before failing. Defaults to 20.
+
+```shell
+poetry run python -m new_albums -t 5
+```

--- a/README.md
+++ b/README.md
@@ -131,13 +131,14 @@ poetry run python -m new_albums
 
 ### Filter by country
 
-By default, the script will filter by US. To filter by a specific country, you can pass the `--country` flag followed by the country ISO code, e.g. `py -m new_albums --country JP`
+By default, the script will only pull new releases from the United States. To filter by specific countries, you can pass the `--country` flag followed by one or more country ISO codes, e.g. `py -m new_albums --country JP`
 
 **Options**:
 - `py -m new_albums`: filters by US
+- `py -m new_albums -c us jp`: filters by US and JP
 - `py -m new_albums --country GB`: filter by GB
-- `py -m new_albums --country list`: list all available Spotify country codes. The script then prompts you to type an ISO code.
-- `py -m new_albums --country all`: include -m new_albums codes (worldwide)
+- `py -m new_albums --country list`: list all available Spotify country codes.
+- `py -m new_albums --country all`: worldwide
 
 `-c` can also be used as an abbreviation for `--country`, e.g. `py -m new_albums -c all`
 

--- a/new_albums/__main__.py
+++ b/new_albums/__main__.py
@@ -72,7 +72,8 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--log",
         "-l",
-        help="Set logging granularity. One of: debug, info, warning, error, critical",
+        help="Set logging granularity. Defaults to 'warning'.",
+        choices=["debug", "info", "warning", "error", "critical"],
         default="warning",
     )
 
@@ -132,7 +133,7 @@ def markets(spotify):
             print(country_name + " = " + "'" + code + "'")
 
     log(
-        "Rerun the script with the desired country code; ex. 'US', 'GB', 'JP', 'ES'... "
+        "Rerun the script with the desired country codes; ex. 'US', 'GB', 'JP', 'ES'... "
     )
 
 
@@ -153,11 +154,11 @@ def parse_country(countries, spotify):
     """
     logging.debug(f"[parse_country]: Parsing country arguments: {countries}")
 
-    if countries == ["ALL"]:
+    if "ALL" in countries:
         # ALL is worldwide (None)
         logging.info(f"[parse_country] Global country filter")
         return [None]
-    elif countries == ["LIST"]:
+    elif "LIST" in countries:
         logging.debug("[parse_country]: Asked for list countries.")
         markets(spotify)
         sys.exit(0)

--- a/new_albums/__main__.py
+++ b/new_albums/__main__.py
@@ -3,6 +3,7 @@ from new_albums.api import get_spotify
 from new_albums.classes.albumClass import albumClass, format_album
 from new_albums.classes.userClass import userClass
 from rich import print
+from typing import Iterable
 import new_albums
 import new_albums.config as config
 import os
@@ -47,8 +48,10 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "-c",
         "--country",
-        help="Allows you to filter by country using an ISO country code. Default is 'US'. Use 'ALL' for worldwide. Use 'LIST' to list all available countries.",
-        default="US",
+        help="Filter by one or more countries using ISO country codes. Default is 'US'. Use 'ALL' for worldwide. Use 'LIST' to list all available countries.",
+        nargs="+",
+        type=str,
+        default=["US"],
     )
 
     # a boolean kwarg should really just be optional and default to bools in memory, not strings
@@ -133,13 +136,13 @@ def markets(spotify):
     )
 
 
-def parse_country(country, spotify):
+def parse_country(countries, spotify):
     """Validate the country code argument.
 
     Parameters
     ----------
-    country : str
-        The country code passed into the script.
+    countries : str | list[str]
+        The country code(s) passed into the script.
     spotify : spotipy.client.Spotipy
         Authenicated Spotipy client.
 
@@ -148,22 +151,31 @@ def parse_country(country, spotify):
     str
         Validated country code.
     """
-    logging.debug(f"[parse_country]: Parsing country code: {country}")
+    logging.debug(f"[parse_country]: Parsing country arguments: {countries}")
 
-    if country == "ALL":
+    if countries == ["ALL"]:
         # ALL is worldwide (None)
         logging.info(f"[parse_country] Global country filter")
-        return None
-    elif country == "LIST":
+        return [None]
+    elif countries == ["LIST"]:
+        logging.debug("[parse_country]: Asked for list countries.")
         markets(spotify)
         sys.exit(0)
-    elif country in spotify.available_markets()["markets"]:
-        logging.info(f"[parse_country] Filtering on country code {country}.")
-        return country
+    elif isinstance(countries, Iterable):
+        logging.debug("[parse_country]: Validating list of countries")
+        all_markets = spotify.available_markets()["markets"]
+        for country in countries:
+            if country in all_markets:
+                logging.info(f"[parse_country] Filtering on country code {country}.")
+            else:
+                logging.error(f"[parse_country] Invalid country code {country}.")
+                raise ValueError(
+                    f"Country code {country} is invalid.\nRun the scripts with `-c list` to see the available markets."
+                )
+
+        return countries
     else:
-        raise ValueError(
-            f"Country code {country} is invalid.\nRun the scripts with `-c list` to see the available markets."
-        )
+        raise ValueError(f"Invalid option passed to -c: {countries}")
 
 
 def init_logging(log_level):
@@ -245,13 +257,16 @@ def main():
 
     # Parse country/markets
     # Calls the Spotify API and therefore requires authentication
-    country = parse_country(args.country.upper(), spotify)
+    countries = [country.upper() for country in args.country]
+    logging.debug(f"[main] Countries after upper: {countries}")
+    countries = parse_country(countries, spotify)
+    logging.debug(f"[main] Countries after parse_country: {countries}")
 
     album = albumClass(spotify, config.FIAT_FILE, args.limit)
 
     # Get albums lists
     processed_albums = album.get_new_album_ids(
-        country=country, filter_by_your_top_genres=filter_by_genre
+        countries=countries, filter_by_your_top_genres=filter_by_genre
     )
 
     track_ids = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "new-albums"
-version = "0.26.0"
+version = "0.35.0"
 description = "A python script to update a Spotify playlist every day with all the songs from any significant new albums. It shouldn't include single-only releases."
 authors = ["Rivers Cuomo"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
Hello again! I updated `-c` to support multiple country codes instead of one. So, now you can do this:

```shell
py -m new_albums -c us jp
```

And the script will filter on the United States and Japan, for example.

I updated `README.md` to reflect this change as well as the new switches from last time.