### PR TITLE
classes/toolsClass: fix unique() logic error

### DIFF
--- a/new_albums/classes/toolsClass.py
+++ b/new_albums/classes/toolsClass.py
@@ -14,5 +14,5 @@ class toolsClass :
             # Csheck if exists in unique_list or not
             if x not in unique_list_of_elements:
                 unique_list_of_elements.append(x)
-        return list_of_elements
+        return unique_list_of_elements
 


### PR DESCRIPTION
The  `unique()` function under  `toolsClass` accidentally
returns the original list instead of the unique-ified list.

BTW, if list order isn't important, `list(set(my_list))`
is much more fast and concise (less room for errors!).
Commented only because the function is used a lot :P
